### PR TITLE
给vue的模版的input加maxlength控制

### DIFF
--- a/maku-generator-server/src/main/resources/template/maku-boot/vue/add-or-update.vue.ftl
+++ b/maku-generator-server/src/main/resources/template/maku-boot/vue/add-or-update.vue.ftl
@@ -4,15 +4,15 @@
 	    <#list formList as field>
 			<#if field.formType == 'text'>
 				<el-form-item label="${field.fieldComment!}" prop="${field.attrName}">
-					<el-input v-model="dataForm.${field.attrName}" placeholder="${field.fieldComment!}"></el-input>
+					<el-input v-model="dataForm.${field.attrName}" placeholder="${field.fieldComment!}" maxlength="200"></el-input>
 				</el-form-item>
 			<#elseif field.formType == 'textarea'>
 				<el-form-item label="${field.fieldComment!}" prop="${field.attrName}">
-					<el-input type="textarea" v-model="dataForm.${field.attrName}"></el-input>
+					<el-input type="textarea" v-model="dataForm.${field.attrName}" maxlength="1000"></el-input>
 				</el-form-item>
 			<#elseif field.formType == 'editor'>
 				<el-form-item label="${field.fieldComment!}" prop="${field.attrName}">
-					<el-input type="textarea" v-model="dataForm.${field.attrName}"></el-input>
+					<el-input type="textarea" v-model="dataForm.${field.attrName}" maxlength="2000"></el-input>
 				</el-form-item>
 			<#elseif field.formType == 'select'>
 				<#if field.formDict??>

--- a/maku-generator-server/src/main/resources/template/maku-boot/vue/index.vue.ftl
+++ b/maku-generator-server/src/main/resources/template/maku-boot/vue/index.vue.ftl
@@ -4,7 +4,7 @@
 		<#list queryList as field>
 			<el-form-item prop="${field.attrName}">
 			<#if field.formType == 'text' || field.formType == 'textarea' || field.formType == 'editor'>
-			  <el-input v-model="state.queryForm.${field.attrName}" placeholder="${field.fieldComment!}"></el-input>
+			  <el-input v-model="state.queryForm.${field.attrName}" placeholder="${field.fieldComment!}" maxlength="100"></el-input>
 			<#elseif field.queryFormType == 'select'>
 			  <#if field.queryDict??>
 			  <ma-dict-select v-model="state.queryForm.${field.attrName}" dict-type="${field.queryDict}" placeholder="${field.fieldComment!}" clearable></ma-dict-select>


### PR DESCRIPTION
生成的vue的代码里面的form表单的input需要加maxlength控制，否则测试团队那边通不过。要求每个输入框都不能无限输入，否则输入超长时，后端会报异常。